### PR TITLE
Fix fopen() mode

### DIFF
--- a/tte.c
+++ b/tte.c
@@ -1067,7 +1067,7 @@ void editorOpen(char* file_name) {
 
     editorSelectSyntaxHighlight();
 
-    FILE* file = fopen(file_name, "a+");
+    FILE* file = fopen(file_name, "r+");
     if (!file)
         die("Failed to open the file");
 


### PR DESCRIPTION
Use r+ instead of a+ which makes more sense since it needs to read from
the beginning of the file.