### PR TITLE
Add support for file extension through argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tte
 
-tte (tiny text editor) is a terminal based text editor written in C from scratch, trying to be very minimalistic and dependency independent (it's not even using **curses**). 
+tte (tiny text editor) is a terminal based text editor written in C from scratch, trying to be very minimalistic and dependency independent (it's not even using **curses**).
 
 This project was mainly created for educational purposes, so is very commented!
 
@@ -19,13 +19,14 @@ Download it from [here](https://github.com/GrenderG/tte/releases/latest), then
 ```
 sudo mv tte /usr/local/bin/
 sudo chmod +x /usr/local/bin/tte
-``` 
+```
 
 ## Usage
 ```
 tte [file_name]
 tte -h | --help
 tte -v | --version
+tte -e | --extension .sh bash_script
 ```
 If you are planning to use special characters like (á, é, í, ó, ú, ¡, ¿, ...) you must use `ISO 8859-1` encoding in your terminal. See [this issue](https://github.com/GrenderG/tte/issues/2) for more info.
 

--- a/tte.c
+++ b/tte.c
@@ -1106,7 +1106,7 @@ void editorSave() {
             editorSetStatusMessage("Save aborted");
             return;
         }
-        editorApplySyntaxHighlight();
+        editorSelectSyntaxHighlight();
     }
 
     int len;


### PR DESCRIPTION
Added support for file extension through argv, example:
```sh
$ tte -e .sh bash_script
```
Moved update syntax highlight to a standalone function.